### PR TITLE
Added remotes package and pulled BiocManager to front.

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,15 @@ ensure all required python packages are installed and available (in the correct
 version) on each system. *basilisk* installs a self-contained conda environment,
 thus, the *SpectriPy* package is independent of the system's Python environment.
 
-To install the package use
+Since *SpectriPy* is currently still in development, you will need the *remotes*
+package to install it from GitHub. If you do not have the *remotes* package yet,
+you can install it using the following command:
+
+```r
+install.packages("remotes")
+```
+
+To install the *SpectriPi* package use
 
 ```r
 BiocManager::install("RforMassSpectrometry/SpectriPy")

--- a/vignettes/SpectriPy.Rmd
+++ b/vignettes/SpectriPy.Rmd
@@ -33,10 +33,16 @@ package.
 
 # Installation
 
-If the *BiocManager* package is not already available, please install it with `install.packages("BiocManager")`.
+If the *BiocManager* package is not already available, 
+please install it with `install.packages("BiocManager")`
+
+To install the development version of *SpectriPy* from GitHub, please install the 
+*remotes* package with `install.packages("remotes").
+
 The package requires a python environment to be available and can be installed
 with the *BiocManager* R package using the command
-`BiocManager::install(c("remotes","RforMassSpectrometry/SpectriPy")`. 
+`BiocManager::install("RforMassSpectrometry/SpectriPy")`. This will install the
+latest version of the package from GitHub.
 All required python libraries are installed automatically on demand. 
 Note that first installation or first invocation of specific functions might 
 take long because of this installation process.
@@ -110,6 +116,9 @@ similar, with the difference that we need to specify and configure the
 similarity function (from *matchms*) using a dedicated parameter object. Below
 we calculate the similarity using the *CosineGreedy* function changing the
 `tolerance` to a value of `0.05` (instead of the default `0.1`).
+
+Executing the following step will automatically download and install conda mini 
+forge to manage Python package dependencies.
 
 ```{r}
 res <- compareSpectriPy(all, caf, param = CosineGreedyParam(tolerance = 0.05))

--- a/vignettes/SpectriPy.Rmd
+++ b/vignettes/SpectriPy.Rmd
@@ -33,13 +33,13 @@ package.
 
 # Installation
 
+If the *BiocManager* package is not already available, please install it with `install.packages("BiocManager")`.
 The package requires a python environment to be available and can be installed
 with the *BiocManager* R package using the command
-`BiocManager::install("RforMassSpectrometry/SpectriPy")`. All required python
-libraries are installed automatically on demand. Note that first installation
-or first invocation of specific functions might take long because of this
-installation process. The *BiocManager* package, if not already available, could
-be installed with `install.packages("BiocManager")`.
+`BiocManager::install(c("remotes","RforMassSpectrometry/SpectriPy")`. 
+All required python libraries are installed automatically on demand. 
+Note that first installation or first invocation of specific functions might 
+take long because of this installation process.
 
 
 # Spectra similarity calculations using `matchms`


### PR DESCRIPTION
Simplify installation for vanilla environments. Mention BiocManager before usage is required.