### PR TITLE
PR: fixing pyspec_to_rspec, check for list 

### DIFF
--- a/R/conversion.R
+++ b/R/conversion.R
@@ -110,8 +110,8 @@ rspec_to_pyspec <- function(x, mapping = spectraVariableMapping(),
 #' @export
 pyspec_to_rspec <- function(x, mapping = spectraVariableMapping(),
                             BPPARAM = SerialParam(), .check = TRUE) {
-    if (!is(x, "python.builtin.list"))
-        stop("'x' is expected to be a Python list.")
+    if (!is(x, "list"))
+      stop("'x' is expected to be a Python list.")
     x <- py_to_r(x)
     if (.check && !all(vapply(x, function(z)
         is(z, "matchms.Spectrum.Spectrum"), logical(1))))
@@ -227,3 +227,4 @@ pyspec_to_rspec <- function(x, mapping = spectraVariableMapping(),
 #' @noRd
 .multi_pyspec_to_rspec <- function() {
 }
+

--- a/R/conversion.R
+++ b/R/conversion.R
@@ -110,7 +110,7 @@ rspec_to_pyspec <- function(x, mapping = spectraVariableMapping(),
 #' @export
 pyspec_to_rspec <- function(x, mapping = spectraVariableMapping(),
                             BPPARAM = SerialParam(), .check = TRUE) {
-    if (!is(x, "list"))
+    if (!(is(x, "list") | is(x, "python.builtin.list")))
       stop("'x' is expected to be a Python list.")
     x <- py_to_r(x)
     if (.check && !all(vapply(x, function(z)


### PR DESCRIPTION
When using `pyspec_to_rspec` with a list of `matchms.Spectrum` objects, `pyspec_to_rspec` throws the error:

```
Error in pyspec_to_rspec(py$res, mapping = vars) : 
  'x' is expected to be a Python list.
```

The PR fixes this by also allowing to be `x` of class `list`.